### PR TITLE
Build fixes: external fdk-aac and missing PMT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ find_package(Doxygen)
 # components required to the list of GR_REQUIRED_COMPONENTS (in all
 # caps such as FILTER or FFT) and change the version to the minimum
 # API compatible version required.
-set(GR_REQUIRED_COMPONENTS RUNTIME FEC)
+set(GR_REQUIRED_COMPONENTS RUNTIME FEC PMT)
 find_package(Gnuradio "3.7.2" REQUIRED)
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 include(GrVersion)
@@ -195,6 +195,11 @@ add_custom_target(uninstall
 ########################################################################
 # Build patched fdk-aac
 ########################################################################
+if (FDK_AAC_LIBRARY AND FDK_AAC_INCLUDE_DIR)
+    add_library(fdk-aac STATIC IMPORTED)
+    set_property(TARGET fdk-aac PROPERTY IMPORTED_LOCATION ${FDK_AAC_LIBRARY})
+    set_property(TARGET fdk-aac PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${FDK_AAC_INCLUDE_DIR})
+else()
 include (ExternalProject)
 
 set (FDK_AAC_PREFIX "${CMAKE_BINARY_DIR}/fdk-aac-prefix")
@@ -214,6 +219,7 @@ add_library (fdk-aac STATIC IMPORTED)
 set_property (TARGET fdk-aac PROPERTY IMPORTED_LOCATION "${FDK_AAC_PREFIX}/lib/libfdk-aac.a")
 add_dependencies (fdk-aac fdk_aac_external)
 include_directories ("${FDK_AAC_PREFIX}/include")
+endif()
 
 ########################################################################
 # Add subdirectories


### PR DESCRIPTION
I was building under MSVC and I needed to build fdk-aac with different build rules. I added a set of variables to specify includes/libs for fdk-aac and left the exsiting external project in-tact.
Usually this would be a more formal find package for cmake, but this handles my needs and should continue to build as-is for existing scenarios.

Also, gr-PMT is a missing required component, I got linker errors without it. Its probably automatically being linked in on other systems. Added PMT to the list of components.