### PR TITLE
Add flowgraph that sends I/Q samples to a sound card

### DIFF
--- a/apps/hd_tx_am_soundcard.grc
+++ b/apps/hd_tx_am_soundcard.grc
@@ -1,0 +1,507 @@
+options:
+  parameters:
+    author: ''
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: no_gui
+    hier_block_src_path: '.:'
+    id: hd_tx_am_soundcard
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ''
+    window_size: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 12]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: audio_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '44100'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 100.0]
+    rotation: 0
+    state: true
+- name: audio_sink_0
+  id: audio_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    device_name: ''
+    num_inputs: '2'
+    ok_to_block: 'True'
+    samp_rate: '44100'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [816, 512.0]
+    rotation: 0
+    state: true
+- name: blocks_add_const_vxx_0
+  id: blocks_add_const_vxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    const: '0.5'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [560, 652.0]
+    rotation: 180
+    state: true
+- name: blocks_add_xx_0
+  id: blocks_add_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_inputs: '2'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [384, 512.0]
+    rotation: 0
+    state: enabled
+- name: blocks_complex_to_float_0
+  id: blocks_complex_to_float
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [640, 512.0]
+    rotation: 0
+    state: true
+- name: blocks_delay_0
+  id: blocks_delay
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    delay: int(audio_rate * 5.5)
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_ports: '1'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [880, 652.0]
+    rotation: 180
+    state: true
+- name: blocks_float_to_complex_0
+  id: blocks_float_to_complex
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [384, 656.0]
+    rotation: 180
+    state: true
+- name: blocks_keep_m_in_n_0
+  id: blocks_keep_m_in_n
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    m: '270'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    n: '512'
+    offset: '121'
+    type: complex
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [720, 420.0]
+    rotation: 180
+    state: enabled
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    const: '0.7'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [480, 524.0]
+    rotation: 0
+    state: true
+- name: blocks_multiply_xx_0
+  id: blocks_multiply_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_inputs: '2'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [592, 408.0]
+    rotation: 180
+    state: enabled
+- name: blocks_null_source_0
+  id: blocks_null_source
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_source: '[[0,],]'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_outputs: '1'
+    type: byte
+    vlen: '24000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [536, 116.0]
+    rotation: 180
+    state: enabled
+- name: blocks_repeat_0
+  id: blocks_repeat
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    interp: '2'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    type: complex
+    vlen: '256'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [880, 244.0]
+    rotation: 0
+    state: enabled
+- name: blocks_vector_source_x_0
+  id: blocks_vector_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    repeat: 'True'
+    tags: '[]'
+    type: complex
+    vector: '[math.sin(math.pi / 2 * i / 14) for i in range(14)] + [1] * (256-14)
+      + [math.cos(math.pi / 2 * i / 14) for i in range(14)]'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [720, 340.0]
+    rotation: 180
+    state: enabled
+- name: blocks_vector_to_stream_0
+  id: blocks_vector_to_stream
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_items: '256'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [880, 440.0]
+    rotation: 180
+    state: enabled
+- name: blocks_wavfile_source_0
+  id: blocks_wavfile_source
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    file: sample_mono.wav
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nchan: '1'
+    repeat: 'True'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [904, 28.0]
+    rotation: 180
+    state: enabled
+- name: blocks_wavfile_source_1
+  id: blocks_wavfile_source
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    file: sample_mono.wav
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nchan: '1'
+    repeat: 'True'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1016, 644.0]
+    rotation: 180
+    state: true
+- name: fft_vxx_0
+  id: fft_vxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    fft_size: '256'
+    forward: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nthreads: '1'
+    shift: 'True'
+    type: complex
+    window: window.rectangular(256)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 220.0]
+    rotation: 0
+    state: enabled
+- name: import_0
+  id: import
+  parameters:
+    alias: ''
+    comment: ''
+    imports: import math
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 172.0]
+    rotation: 0
+    state: enabled
+- name: low_pass_filter_1
+  id: low_pass_filter
+  parameters:
+    affinity: ''
+    alias: ''
+    beta: '6.76'
+    comment: ''
+    cutoff_freq: '4500'
+    decim: '1'
+    gain: '0.5'
+    interp: '1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_rate: audio_rate
+    type: fir_filter_fff
+    width: '1000'
+    win: firdes.WIN_HAMMING
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [704, 604.0]
+    rotation: 180
+    state: true
+- name: nrsc5_hdc_encoder_0
+  id: nrsc5_hdc_encoder
+  parameters:
+    affinity: ''
+    alias: ''
+    bitrate: '17900'
+    channels: '1'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [736, 28.0]
+    rotation: 180
+    state: enabled
+- name: nrsc5_l1_am_encoder_ma1_0
+  id: nrsc5_l1_am_encoder_ma1
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 88.0]
+    rotation: 180
+    state: true
+- name: nrsc5_l2_encoder_0
+  id: nrsc5_l2_encoder
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    first_prog: '0'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_progs: '1'
+    size: '3750'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [536, 36.0]
+    rotation: 180
+    state: enabled
+- name: nrsc5_psd_encoder_0
+  id: nrsc5_psd_encoder
+  parameters:
+    affinity: ''
+    alias: ''
+    artist: Artist
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    prog_num: '0'
+    title: Title
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [736, 100.0]
+    rotation: 180
+    state: enabled
+- name: nrsc5_sis_encoder_0
+  id: nrsc5_sis_encoder
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    short_name: ABCD
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [536, 164.0]
+    rotation: 180
+    state: enabled
+- name: rational_resampler_xxx_1
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '135'
+    fbw: '0'
+    interp: '128'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [384, 396.0]
+    rotation: 180
+    state: enabled
+
+connections:
+- [blocks_add_const_vxx_0, '0', blocks_float_to_complex_0, '0']
+- [blocks_add_xx_0, '0', blocks_multiply_const_vxx_0, '0']
+- [blocks_complex_to_float_0, '0', audio_sink_0, '0']
+- [blocks_complex_to_float_0, '1', audio_sink_0, '1']
+- [blocks_delay_0, '0', low_pass_filter_1, '0']
+- [blocks_float_to_complex_0, '0', blocks_add_xx_0, '1']
+- [blocks_keep_m_in_n_0, '0', blocks_multiply_xx_0, '1']
+- [blocks_multiply_const_vxx_0, '0', blocks_complex_to_float_0, '0']
+- [blocks_multiply_xx_0, '0', rational_resampler_xxx_1, '0']
+- [blocks_null_source_0, '0', nrsc5_l1_am_encoder_ma1_0, '1']
+- [blocks_repeat_0, '0', blocks_vector_to_stream_0, '0']
+- [blocks_vector_source_x_0, '0', blocks_multiply_xx_0, '0']
+- [blocks_vector_to_stream_0, '0', blocks_keep_m_in_n_0, '0']
+- [blocks_wavfile_source_0, '0', nrsc5_hdc_encoder_0, '0']
+- [blocks_wavfile_source_1, '0', blocks_delay_0, '0']
+- [fft_vxx_0, '0', blocks_repeat_0, '0']
+- [low_pass_filter_1, '0', blocks_add_const_vxx_0, '0']
+- [nrsc5_hdc_encoder_0, '0', nrsc5_l2_encoder_0, '0']
+- [nrsc5_l1_am_encoder_ma1_0, '0', fft_vxx_0, '0']
+- [nrsc5_l2_encoder_0, '0', nrsc5_l1_am_encoder_ma1_0, '0']
+- [nrsc5_psd_encoder_0, '0', nrsc5_l2_encoder_0, '1']
+- [nrsc5_sis_encoder_0, '0', nrsc5_l1_am_encoder_ma1_0, '2']
+- [rational_resampler_xxx_1, '0', blocks_add_xx_0, '0']
+
+metadata:
+  file_format: 1

--- a/apps/hd_tx_am_soundcard.py
+++ b/apps/hd_tx_am_soundcard.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#
+# SPDX-License-Identifier: GPL-3.0
+#
+# GNU Radio Python Flow Graph
+# Title: Hd Tx Am Soundcard
+# GNU Radio version: 3.8.2.0
+
+from gnuradio import audio
+from gnuradio import blocks
+from gnuradio import fft
+from gnuradio.fft import window
+from gnuradio import filter
+from gnuradio.filter import firdes
+from gnuradio import gr
+import sys
+import signal
+from argparse import ArgumentParser
+from gnuradio.eng_arg import eng_float, intx
+from gnuradio import eng_notation
+import math
+import nrsc5
+
+
+class hd_tx_am_soundcard(gr.top_block):
+
+    def __init__(self):
+        gr.top_block.__init__(self, "Hd Tx Am Soundcard")
+
+        ##################################################
+        # Variables
+        ##################################################
+        self.audio_rate = audio_rate = 44100
+
+        ##################################################
+        # Blocks
+        ##################################################
+        self.rational_resampler_xxx_1 = filter.rational_resampler_ccc(
+                interpolation=128,
+                decimation=135,
+                taps=None,
+                fractional_bw=None)
+        self.nrsc5_sis_encoder_0 = nrsc5.sis_encoder('ABCD')
+        self.nrsc5_psd_encoder_0 = nrsc5.psd_encoder(0, 'Title', 'Artist')
+        self.nrsc5_l2_encoder_0 = nrsc5.l2_encoder(1, 0, 3750)
+        self.nrsc5_l1_am_encoder_ma1_0 = nrsc5.l1_am_encoder(1)
+        self.nrsc5_hdc_encoder_0 = nrsc5.hdc_encoder(1, 17900)
+        self.low_pass_filter_1 = filter.fir_filter_fff(
+            1,
+            firdes.low_pass(
+                0.5,
+                audio_rate,
+                4500,
+                1000,
+                firdes.WIN_HAMMING,
+                6.76))
+        self.fft_vxx_0 = fft.fft_vcc(256, False, window.rectangular(256), True, 1)
+        self.blocks_wavfile_source_1 = blocks.wavfile_source('sample_mono.wav', True)
+        self.blocks_wavfile_source_0 = blocks.wavfile_source('sample_mono.wav', True)
+        self.blocks_vector_to_stream_0 = blocks.vector_to_stream(gr.sizeof_gr_complex*1, 256)
+        self.blocks_vector_source_x_0 = blocks.vector_source_c([math.sin(math.pi / 2 * i / 14) for i in range(14)] + [1] * (256-14) + [math.cos(math.pi / 2 * i / 14) for i in range(14)], True, 1, [])
+        self.blocks_repeat_0 = blocks.repeat(gr.sizeof_gr_complex*256, 2)
+        self.blocks_null_source_0 = blocks.null_source(gr.sizeof_char*24000)
+        self.blocks_multiply_xx_0 = blocks.multiply_vcc(1)
+        self.blocks_multiply_const_vxx_0 = blocks.multiply_const_cc(0.7)
+        self.blocks_keep_m_in_n_0 = blocks.keep_m_in_n(gr.sizeof_gr_complex, 270, 512, 121)
+        self.blocks_float_to_complex_0 = blocks.float_to_complex(1)
+        self.blocks_delay_0 = blocks.delay(gr.sizeof_float*1, int(audio_rate * 5.5))
+        self.blocks_complex_to_float_0 = blocks.complex_to_float(1)
+        self.blocks_add_xx_0 = blocks.add_vcc(1)
+        self.blocks_add_const_vxx_0 = blocks.add_const_ff(0.5)
+        self.audio_sink_0 = audio.sink(44100, '', True)
+
+
+
+        ##################################################
+        # Connections
+        ##################################################
+        self.connect((self.blocks_add_const_vxx_0, 0), (self.blocks_float_to_complex_0, 0))
+        self.connect((self.blocks_add_xx_0, 0), (self.blocks_multiply_const_vxx_0, 0))
+        self.connect((self.blocks_complex_to_float_0, 0), (self.audio_sink_0, 0))
+        self.connect((self.blocks_complex_to_float_0, 1), (self.audio_sink_0, 1))
+        self.connect((self.blocks_delay_0, 0), (self.low_pass_filter_1, 0))
+        self.connect((self.blocks_float_to_complex_0, 0), (self.blocks_add_xx_0, 1))
+        self.connect((self.blocks_keep_m_in_n_0, 0), (self.blocks_multiply_xx_0, 1))
+        self.connect((self.blocks_multiply_const_vxx_0, 0), (self.blocks_complex_to_float_0, 0))
+        self.connect((self.blocks_multiply_xx_0, 0), (self.rational_resampler_xxx_1, 0))
+        self.connect((self.blocks_null_source_0, 0), (self.nrsc5_l1_am_encoder_ma1_0, 1))
+        self.connect((self.blocks_repeat_0, 0), (self.blocks_vector_to_stream_0, 0))
+        self.connect((self.blocks_vector_source_x_0, 0), (self.blocks_multiply_xx_0, 0))
+        self.connect((self.blocks_vector_to_stream_0, 0), (self.blocks_keep_m_in_n_0, 0))
+        self.connect((self.blocks_wavfile_source_0, 0), (self.nrsc5_hdc_encoder_0, 0))
+        self.connect((self.blocks_wavfile_source_1, 0), (self.blocks_delay_0, 0))
+        self.connect((self.fft_vxx_0, 0), (self.blocks_repeat_0, 0))
+        self.connect((self.low_pass_filter_1, 0), (self.blocks_add_const_vxx_0, 0))
+        self.connect((self.nrsc5_hdc_encoder_0, 0), (self.nrsc5_l2_encoder_0, 0))
+        self.connect((self.nrsc5_l1_am_encoder_ma1_0, 0), (self.fft_vxx_0, 0))
+        self.connect((self.nrsc5_l2_encoder_0, 0), (self.nrsc5_l1_am_encoder_ma1_0, 0))
+        self.connect((self.nrsc5_psd_encoder_0, 0), (self.nrsc5_l2_encoder_0, 1))
+        self.connect((self.nrsc5_sis_encoder_0, 0), (self.nrsc5_l1_am_encoder_ma1_0, 2))
+        self.connect((self.rational_resampler_xxx_1, 0), (self.blocks_add_xx_0, 0))
+
+
+    def get_audio_rate(self):
+        return self.audio_rate
+
+    def set_audio_rate(self, audio_rate):
+        self.audio_rate = audio_rate
+        self.blocks_delay_0.set_dly(int(self.audio_rate * 5.5))
+        self.low_pass_filter_1.set_taps(firdes.low_pass(0.5, self.audio_rate, 4500, 1000, firdes.WIN_HAMMING, 6.76))
+
+
+
+
+
+def main(top_block_cls=hd_tx_am_soundcard, options=None):
+    tb = top_block_cls()
+
+    def sig_handler(sig=None, frame=None):
+        tb.stop()
+        tb.wait()
+
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
+    tb.start()
+
+    try:
+        input('Press Enter to quit: ')
+    except EOFError:
+        pass
+    tb.stop()
+    tb.wait()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This flowgraph could be used with RF hardware that accepts I/Q samples from a stereo sound card.

![hd_tx_am_soundcard](https://user-images.githubusercontent.com/583749/95782557-0d27a480-0c9e-11eb-97ed-ed9deb86755e.png)