### PR TITLE
Update send_album_art.py

### DIFF
--- a/apps/send_album_art.py
+++ b/apps/send_album_art.py
@@ -2,6 +2,7 @@
 
 import argparse
 import socket
+from socket import SHUT_RDWR
 import os
 
 parser = argparse.ArgumentParser()
@@ -21,10 +22,12 @@ s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect((args.host, args.file_port))
 s.send(command)
 s.send(data)
+s.shutdown(SHUT_RDWR)
 s.close()
 
 command = f"lot{args.lot_id}\n".encode()
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect((args.host, args.psd_port))
 s.send(command)
+s.shutdown(SHUT_RDWR)
 s.close()

--- a/apps/send_album_art.py
+++ b/apps/send_album_art.py
@@ -2,7 +2,6 @@
 
 import argparse
 import socket
-from socket import SHUT_RDWR
 import os
 
 parser = argparse.ArgumentParser()
@@ -22,12 +21,12 @@ s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect((args.host, args.file_port))
 s.send(command)
 s.send(data)
-s.shutdown(SHUT_RDWR)
+s.shutdown(socket.SHUT_RDWR)
 s.close()
 
 command = f"lot{args.lot_id}\n".encode()
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect((args.host, args.psd_port))
 s.send(command)
-s.shutdown(SHUT_RDWR)
+s.shutdown(socket.SHUT_RDWR)
 s.close()


### PR DESCRIPTION
After extensive debugging with the Socket PDUs for HD Album Art and Title/Artist, I have determined that around the 10-12 hour mark of running the program, it outputs the following error for each Socket PDU:

`socket pdu :error: system:24`

After doing some research on this error, I have found out that the way the current send_album_art script is coded that it doesn't properly close and shutdown the connection after album art is sent, meaning that after a certain amount of time running the script, it causes a buffer Receive Queue on the TCP sockets.

![image](https://github.com/argilo/gr-nrsc5/assets/40074095/4a0c8ee4-488f-47e3-b9a2-09512c5c60ad)

This Recv-Q value means that the TCP socket is queuing any additional data that is sent to it after the buffer overflows. Since GNURadio doesn't adequately handle the closing and shutdown of connections through Socket PDU blocks, setting the python script to handle the shutdown itself patches this issue.